### PR TITLE
WIP: fix rust tests for big-endian targets

### DIFF
--- a/rust/flatbuffers/src/vector.rs
+++ b/rust/flatbuffers/src/vector.rs
@@ -19,7 +19,9 @@ use std::mem::size_of;
 use std::slice::from_raw_parts;
 use std::str::from_utf8_unchecked;
 
-use endian_scalar::{EndianScalar, read_scalar};
+#[cfg(target_endian = "little")]
+use endian_scalar::EndianScalar;
+use endian_scalar::read_scalar;
 use follow::Follow;
 use primitives::*;
 
@@ -105,6 +107,7 @@ impl<'a> Follow<'a> for &'a str {
     }
 }
 
+#[cfg(target_endian = "little")]
 fn follow_slice_helper<T>(buf: &[u8], loc: usize) -> &[T] {
     let sz = size_of::<T>();
     debug_assert!(sz > 0);

--- a/tests/RustTest.sh
+++ b/tests/RustTest.sh
@@ -15,8 +15,14 @@ set -e
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if [[ "$1" == "mips-unknown-linux-gnu" ]]; then
+    TARGET_FLAG="--target mips-unknown-linux-gnu"
+    export CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_LINKER=mips-linux-gnu-gcc
+    export CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_RUNNER="qemu-mips -L /usr/mips-linux-gnu"
+fi
+
 cd ./rust_usage_test
-cargo test -- --quiet
+cargo test $TARGET_FLAG -- --quiet
 TEST_RESULT=$?
 if [[ $TEST_RESULT  == 0 ]]; then
     echo "OK: Rust tests passed."
@@ -25,7 +31,7 @@ else
     exit 1
 fi
 
-cargo run --bin=alloc_check
+cargo run $TARGET_FLAG --bin=alloc_check
 TEST_RESULT=$?
 if [[ $TEST_RESULT  == 0 ]]; then
     echo "OK: Rust heap alloc test passed."
@@ -34,4 +40,4 @@ else
     exit 1
 fi
 
-cargo bench
+cargo bench $TARGET_FLAG

--- a/tests/docker/languages/Dockerfile.testing.rust.big_endian.1_30_1
+++ b/tests/docker/languages/Dockerfile.testing.rust.big_endian.1_30_1
@@ -1,16 +1,15 @@
 FROM rust:1.30.1-slim-stretch as base
-
-WORKDIR /setup
-RUN apt -qq update >/dev/null
-RUN apt -qq install -y curl gcc-mips-linux-gnu qemu-user
-RUN curl https://sh.rustup.rs > rustup.sh
-RUN cat rustup.sh | sh -s -- -y --default-toolchain none
+RUN apt -qq update -y && apt -qq install -y \
+    gcc-mips-linux-gnu \
+    libexpat1 \
+    libmagic1 \
+    libmpdec2 \
+    libreadline7 \
+    qemu-user
 RUN rustup target add mips-unknown-linux-gnu
-
-
 WORKDIR /code
 ADD . .
-WORKDIR /code/tests/rust_usage_test
-ENV CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_LINKER=mips-linux-gnu-gcc
-ENV CARGO_TARGET_MIPS_UNKNOWN_LINUX_GNU_RUNNER="qemu-mips -L /usr/mips-linux-gnu"
-RUN cargo test --target mips-unknown-linux-gnu
+RUN cp flatc_debian_stretch flatc
+WORKDIR /code/tests
+RUN rustc --version
+RUN ./RustTest.sh mips-unknown-linux-gnu


### PR DESCRIPTION
This pull request is meant to complement [this pull request](https://github.com/google/flatbuffers/pull/5093) into the main flatbuffers repo. It resolves test failures for big-endian targets in the Rust crate.